### PR TITLE
Add input for abrupt crash

### DIFF
--- a/main.py
+++ b/main.py
@@ -137,3 +137,5 @@ else:
             print(f"{Fore.WHITE}[ {Fore.RED}- {Fore.WHITE}] {Fore.LIGHTBLACK_EX}Failed connecting to proxy {Fore.WHITE}{proxi}{Fore.LIGHTBLACK_EX} | Removing from list!")
 
 print(f"{Fore.WHITE}[ {Fore.YELLOW}? {Fore.WHITE}] {Fore.LIGHTBLACK_EX}Succefully generated {Fore.WHITE}{fulla} {Fore.LIGHTBLACK_EX}codes!{Fore.WHITE}")
+
+input()


### PR DESCRIPTION
Prevent the script from getting to EOF and crashing (not really) so anybody who does not execute this from terminal does not know why it crashed